### PR TITLE
Feat: add formatted program and bootloader version logging

### DIFF
--- a/lenz_flashtool/flashtool/core.py
+++ b/lenz_flashtool/flashtool/core.py
@@ -1598,6 +1598,16 @@ class FlashTool:
                             + "(UTC)")
             except UnicodeDecodeError:
                 pass
+            program_val = endict['Program   ']
+            program_bytes = [f"{int(program_val[i:i+2], 16):02d}" for i in range(0, 8, 2)]
+            program_bytes_reversed = program_bytes[::-1]
+            program_formatted = '.'.join(program_bytes_reversed)
+            bootloader_val = endict['Bootloader']
+            bootloader_bytes = [f"{int(bootloader_val[i:i+2], 16):02d}" for i in range(0, 8, 2)]
+            bootloader_bytes_reversed = bootloader_bytes[::-1]
+            bootloader_formatted = '.'.join(bootloader_bytes_reversed)
+            logger.info(f"Program: {program_formatted}, " +
+                        f"Bootloader: {bootloader_formatted}")
             logger.debug('Raw encoder answer: %s', ans)
             return (
                 endict["Bootloader"],


### PR DESCRIPTION
- Extract and format program version from hex to decimal bytes (reversed order)
- Extract and format bootloader version from hex to decimal bytes (reversed order)
- Add new log output showing human-readable version formats: 'Program: X.X.X.X, Bootloader: Y.Y.Y.Y'
- Maintain existing raw hex data return values for backward compatibility

Example output:
Program: 01.01.05.2D, Bootloader: 01.00.01.00